### PR TITLE
chore: downgrade required role to datastore.user

### DIFF
--- a/firestore-webflow-sync/extension.yaml
+++ b/firestore-webflow-sync/extension.yaml
@@ -37,7 +37,7 @@ contributors:
 billingRequired: true
 
 roles:
-  - role: datastore.owner
+  - role: datastore.user
     reason:
       Allows the extension to create, update and delete user data from Cloud
       Firestore.


### PR DESCRIPTION
I think `datastore.user` should be sufficient here?